### PR TITLE
set output path to chunks folder inside static

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ module.exports = (nextConfig = {}) => {
             options: {
               limit: 8192,
               fallback: 'file-loader',
-              publicPath: `${assetPrefix}/_next/static/fonts/`,
-              outputPath: `${isServer ? "../" : ""}static/fonts/`,
+              publicPath: `${assetPrefix}/_next/static/chunks/fonts/`,
+              outputPath: `${isServer ? "../" : ""}static/chunks/fonts/`,
               name: '[name]-[hash].[ext]'
             }
           }


### PR DESCRIPTION
avoids issue with cache-control maxage being set to 0